### PR TITLE
Fix strong mode errors

### DIFF
--- a/lib/src/date_time.dart
+++ b/lib/src/date_time.dart
@@ -116,7 +116,7 @@ class TZDateTime implements DateTime {
       int second = 0,
       int millisecond = 0,
       int microsecond = 0])
-      : this._fromUtc(
+      : this.from(
             _utcFromLocalDateTime(
                 new DateTime.utc(year, month, day, hour, minute, second,
                     millisecond, microsecond),

--- a/lib/src/date_time.dart
+++ b/lib/src/date_time.dart
@@ -118,7 +118,8 @@ class TZDateTime implements DateTime {
       int microsecond = 0])
       : this.from(
             _utcFromLocalDateTime(
-                new DateTime.utc(year, month, day, hour, minute, second,
+            st
+            new DateTime.utc(year, month, day, hour, minute, second,
                     millisecond, microsecond),
                 location),
             location);
@@ -214,7 +215,7 @@ class TZDateTime implements DateTime {
   /// The function parses a subset of ISO 8601
   /// which includes the subset accepted by RFC 3339.
   ///
-  /// The result is always converted to the provided time zone.
+  /// The result is always in the time zone of the provided location.
   ///
   /// Examples of accepted strings:
   ///

--- a/lib/src/date_time.dart
+++ b/lib/src/date_time.dart
@@ -21,9 +21,10 @@ class TZDateTime implements DateTime {
 
   TimeZone _timeZone;
 
-  /// Native [DateTime] is used as a Calendar object
+  /// Native [DateTime] used as a Calendar object.
   DateTime _localDateTime;
 
+  /// Native [DateTime] used as canonical, utc representation.
   DateTime _utc;
 
   /// The number of milliseconds since
@@ -36,6 +37,17 @@ class TZDateTime implements DateTime {
   /// In other words: [:millisecondsSinceEpoch.abs() <= 8640000000000000:].
   int get millisecondsSinceEpoch => _utc.millisecondsSinceEpoch;
 
+  /// The number of microseconds since the "Unix epoch"
+  /// 1970-01-01T00:00:00Z (UTC).
+  ///
+  /// This value is independent of the time zone.
+  ///
+  /// This value is at most 8,640,000,000,000,000,000us (100,000,000 days) from
+  /// the Unix epoch. In other words:
+  /// microsecondsSinceEpoch.abs() <= 8640000000000000000.
+  ///
+  /// Note that this value does not fit into 53 bits (the size of a IEEE
+  /// double).  A JavaScript number is not able to hold this value.
   int get microsecondsSinceEpoch => _utc.microsecondsSinceEpoch;
 
   /// [Location]
@@ -89,7 +101,6 @@ class TZDateTime implements DateTime {
       _timeZone = const TimeZone(0, false, 'UTC');
       _utc = _localDateTime;
     } else {
-      // TODO(hcameron) fix this.
       var unix = _localDateTime.millisecondsSinceEpoch;
       var tzData = _location.lookupTimeZone(unix);
       if (tzData.timeZone.offset != 0) {
@@ -102,7 +113,7 @@ class TZDateTime implements DateTime {
         unix -= tzData.timeZone.offset;
       }
       _timeZone = _location.timeZone(unix);
-      _localDateTime = _utc.subtract(timeZoneOffset);
+      _utc = _localDateTime.subtract(timeZoneOffset);
     }
   }
 
@@ -252,8 +263,8 @@ class TZDateTime implements DateTime {
   String toString() => toIso8601String();
 
   /// Returns an ISO-8601 full-precision extended format representation.
-  /// The format is "YYYY-MM-DDTHH:mm:ss.sss[sss]Z" for UTC time, and
-  /// "YYYY-MM-DDTHH:mm:ss.sss[sss]±hhmm" (no trailing "Z") for non-UTC time.
+  /// The format is "YYYY-MM-DDTHH:mm:ss.mmm[uuu]Z" for UTC time, and
+  /// "YYYY-MM-DDTHH:mm:ss.mmm[uuu]±hhmm" for non-UTC time.
   String toIso8601String() {
     var offset = _timeZone.offset;
 
@@ -351,7 +362,7 @@ class TZDateTime implements DateTime {
   bool isAtSameMomentAs(DateTime other) => _utc == _toNative(other);
 
   /// Compares this [TZDateTime] object to [other],
-  /// returning zero if the values are equal.
+  /// returning zero if the values occur at the same moment.
   ///
   /// This function returns a negative integer
   /// if this [TZDateTime] is smaller (earlier) than [other],

--- a/lib/src/date_time.dart
+++ b/lib/src/date_time.dart
@@ -171,7 +171,7 @@ class TZDateTime implements DateTime {
       : this._from(_toNative(other).toUtc(), location);
 
   TZDateTime._from(DateTime other, Location location, {otherIsUtc: true})
-      : this._fromWithTimeZone(
+      : this._fromTimeZone(
             other,
             location,
             _isUtc(location)
@@ -196,8 +196,8 @@ class TZDateTime implements DateTime {
     return location.timeZone(unix);
   }
 
-  TZDateTime._fromWithTimeZone(
-      DateTime other, Location location, TimeZone timeZone, {otherIsUtc: true})
+  TZDateTime._fromTimeZone(DateTime other, Location location, TimeZone timeZone,
+      {otherIsUtc: true})
       : this._(
             _isUtc(location) || otherIsUtc
                 ? other

--- a/lib/src/date_time.dart
+++ b/lib/src/date_time.dart
@@ -15,6 +15,8 @@ class TZDateTime implements DateTime {
   /// Minimum value for time instants.
   static const int minMillisecondsSinceEpoch = -maxMillisecondsSinceEpoch;
 
+  static DateTime _toNative(DateTime t) => t is TZDateTime ? t._utc : t;
+
   Location _location;
 
   TimeZone _timeZone;
@@ -286,7 +288,7 @@ class TZDateTime implements DateTime {
       new TZDateTime.from(_utc.subtract(duration), _location);
 
   /// Returns a [Duration] with the difference between [this] and [other].
-  Duration difference(TZDateTime other) => _utc.difference(other._utc);
+  Duration difference(DateTime other) => _utc.difference(_toNative(other));
 
   /// Returns true if [other] is a [TZDateTime] at the same moment and in the
   /// same [Location].
@@ -300,7 +302,6 @@ class TZDateTime implements DateTime {
   /// ````
   ///
   /// See [isAtSameMomentAs] for a comparison that adjusts for time zone.
-  // TODO(hcameron) should this accept DateTimes as well?
   bool operator ==(other) {
     return identical(this, other) ||
         other is TZDateTime &&
@@ -347,7 +348,7 @@ class TZDateTime implements DateTime {
   ///
   /// assert(berlinWallFell.isAtSameMomentAs(moonLanding) == false);
   /// ```
-  bool isAtSameMomentAs(TZDateTime other) => _utc == other._utc;
+  bool isAtSameMomentAs(DateTime other) => _utc == _toNative(other);
 
   /// Compares this [TZDateTime] object to [other],
   /// returning zero if the values are equal.
@@ -355,7 +356,7 @@ class TZDateTime implements DateTime {
   /// This function returns a negative integer
   /// if this [TZDateTime] is smaller (earlier) than [other],
   /// or a positive integer if it is greater (later).
-  int compareTo(TZDateTime other) => _utc.compareTo(other._utc);
+  int compareTo(DateTime other) => _utc.compareTo(_toNative(other));
 
   int get hashCode => _utc.hashCode;
 

--- a/lib/src/date_time.dart
+++ b/lib/src/date_time.dart
@@ -168,8 +168,7 @@ class TZDateTime implements DateTime {
   /// final detroitTime = new TZDateTime.from(detroit, laTime);
   /// ```
   TZDateTime.from(DateTime other, Location location)
-      : this._from(
-            other is TZDateTime ? other._utcDateTime : other.toUtc, location);
+      : this._from(_toNative(other).toUtc(), location);
 
   TZDateTime._from(DateTime other, Location location, {otherIsUtc: true})
       : this._fromWithTimeZone(

--- a/lib/src/env.dart
+++ b/lib/src/env.dart
@@ -62,7 +62,7 @@ void initializeDatabase(List<int> rawData) {
   }
 
   if (_UTC == null) {
-    _UTC = new Location('UTC', [minTime], [0], [const TimeZone(0, false, 'UTC')]);
+    _UTC = new Location('UTC', [minTime], [0], [TimeZone.UTC]);
   }
 
   if (_local == null) {

--- a/lib/src/location.dart
+++ b/lib/src/location.dart
@@ -36,7 +36,8 @@ class Location {
   final List<TimeZone> zones;
 
   /// [TimeZone] for the current time.
-  TimeZone get currentTimeZone => timeZone(new DateTime.now().millisecondsSinceEpoch);
+  TimeZone get currentTimeZone =>
+      timeZone(new DateTime.now().millisecondsSinceEpoch);
 
   // Most lookups will be for the current time.
   // To avoid the binary search through tx, keep a
@@ -59,7 +60,8 @@ class Location {
       final tAt = transitionAt[i];
 
       if ((tAt <= _cacheNow) &&
-          ((i + 1 == transitionAt.length) || (_cacheNow < transitionAt[i + 1]))) {
+          ((i + 1 == transitionAt.length) ||
+              (_cacheNow < transitionAt[i + 1]))) {
         _cacheStart = tAt;
         _cacheEnd = maxTime;
         if (i + 1 < transitionAt.length) {
@@ -90,7 +92,8 @@ class Location {
       utc -= tz.offset;
 
       if (utc < start) {
-        utc = millisecondsSinceEpoch - lookupTimeZone(start - 1).timeZone.offset;
+        utc =
+            millisecondsSinceEpoch - lookupTimeZone(start - 1).timeZone.offset;
       } else if (utc >= end) {
         utc = millisecondsSinceEpoch - lookupTimeZone(end).timeZone.offset;
       }
@@ -237,8 +240,12 @@ class TimeZone {
 
   const TimeZone(this.offset, this.isDst, this.abbr);
 
-  bool operator ==(TimeZone other) {
-    return (offset == other.offset && isDst == other.isDst && abbr == other.abbr);
+  bool operator ==(other) {
+    return identical(this, other) ||
+        other is TimeZone &&
+            offset == other.offset &&
+            isDst == other.isDst &&
+            abbr == other.abbr;
   }
 
   int get hashCode {

--- a/lib/src/location.dart
+++ b/lib/src/location.dart
@@ -2,7 +2,6 @@
 // file for details. All rights reserved. Use of this source code is governed
 // by a BSD-style license that can be found in the LICENSE file.
 
-///
 /// TimeZone Location Info.
 ///
 /// Most of this code were taken from the go standard library
@@ -106,7 +105,7 @@ class Location {
   /// as milliseconds since January 1, 1970 00:00:00 UTC.
   TzInstant lookupTimeZone(int millisecondsSinceEpoch) {
     if (zones.isEmpty) {
-      return const TzInstant(const TimeZone(0, false, 'UTC'), minTime, maxTime);
+      return const TzInstant(TimeZone.UTC, minTime, maxTime);
     }
 
     if (_cacheZone != null &&
@@ -229,6 +228,8 @@ class Location {
 
 /// A [TimeZone] represents a single time zone such as CEST or CET.
 class TimeZone {
+  static const TimeZone UTC = const TimeZone(0, false, 'UTC');
+
   /// Milliseconds east of UTC.
   final int offset;
 

--- a/test/datetime_browser_test.dart
+++ b/test/datetime_browser_test.dart
@@ -27,8 +27,15 @@ main() async {
     });
 
     test('fromMilliseconds', () {
-      final t = new TZDateTime.fromMillisecondsSinceEpoch(newYork, 1262430245006);
+      final t =
+          new TZDateTime.fromMillisecondsSinceEpoch(newYork, 1262430245006);
       expect(t.toString(), equals('2010-01-02 06:04:05.006-0500'));
+    });
+
+    test('fromMicroseconds', () {
+      final t =
+          new TZDateTime.fromMicrosecondsSinceEpoch(newYork, 1262430245006007);
+      expect(t.toString(), equals('2010-01-02 06:04:05.006007-0500'));
     });
 
     test('utc', () {
@@ -89,35 +96,45 @@ main() async {
     group('America/Detroit to UTC', () {
       group('EWT/EPT boundaries', () {
         final x1 = new TZDateTime(detroit, 1945, 9, 30, 1);
-        final u1 = new DateTime.fromMillisecondsSinceEpoch(x1.millisecondsSinceEpoch, isUtc: true);
+        final u1 = new DateTime.fromMillisecondsSinceEpoch(
+            x1.millisecondsSinceEpoch,
+            isUtc: true);
 
         test('$x1 => 1945-09-30 05:00:00.000Z', () {
           expect(u1.toString(), '1945-09-30 05:00:00.000Z');
         });
 
         final x2 = x1.subtract(const Duration(milliseconds: 1));
-        final u2 = new DateTime.fromMillisecondsSinceEpoch(x2.millisecondsSinceEpoch, isUtc: true);
+        final u2 = new DateTime.fromMillisecondsSinceEpoch(
+            x2.millisecondsSinceEpoch,
+            isUtc: true);
 
         test('$x2 => 1945-09-30 04:59:59.999Z', () {
           expect(u2.toString(), equals('1945-09-30 04:59:59.999Z'));
         });
 
         final x3 = x1.add(const Duration(milliseconds: 1));
-        final u3 = new DateTime.fromMillisecondsSinceEpoch(x3.millisecondsSinceEpoch, isUtc: true);
+        final u3 = new DateTime.fromMillisecondsSinceEpoch(
+            x3.millisecondsSinceEpoch,
+            isUtc: true);
 
         test('$x3 => 1945-09-30 05:00:00.001Z', () {
           expect(u3.toString(), equals('1945-09-30 05:00:00.001Z'));
         });
 
         final x4 = x1.add(const Duration(hours: 1));
-        final u4 = new DateTime.fromMillisecondsSinceEpoch(x4.millisecondsSinceEpoch, isUtc: true);
+        final u4 = new DateTime.fromMillisecondsSinceEpoch(
+            x4.millisecondsSinceEpoch,
+            isUtc: true);
 
         test('$x4 => 1945-09-30 06:00:00.000Z', () {
           expect(u4.toString(), equals('1945-09-30 06:00:00.000Z'));
         });
 
         final x5 = x2.add(const Duration(hours: 1));
-        final u5 = new DateTime.fromMillisecondsSinceEpoch(x5.millisecondsSinceEpoch, isUtc: true);
+        final u5 = new DateTime.fromMillisecondsSinceEpoch(
+            x5.millisecondsSinceEpoch,
+            isUtc: true);
 
         test('$x5 => 1945-09-30 05:59:59.999Z', () {
           expect(u5.toString(), equals('1945-09-30 05:59:59.999Z'));

--- a/test/datetime_test.dart
+++ b/test/datetime_test.dart
@@ -27,8 +27,15 @@ main() async {
     });
 
     test('fromMilliseconds', () {
-      final t = new TZDateTime.fromMillisecondsSinceEpoch(newYork, 1262430245006);
+      final t =
+          new TZDateTime.fromMillisecondsSinceEpoch(newYork, 1262430245006);
       expect(t.toString(), equals('2010-01-02 06:04:05.006-0500'));
+    });
+
+    test('fromMicroseconds', () {
+      final t =
+          new TZDateTime.fromMicrosecondsSinceEpoch(newYork, 1262430245006007);
+      expect(t.toString(), equals('2010-01-02 06:04:05.006007-0500'));
     });
 
     test('utc', () {
@@ -89,35 +96,45 @@ main() async {
     group('America/Detroit to UTC', () {
       group('EWT/EPT boundaries', () {
         final x1 = new TZDateTime(detroit, 1945, 9, 30, 1);
-        final u1 = new DateTime.fromMillisecondsSinceEpoch(x1.millisecondsSinceEpoch, isUtc: true);
+        final u1 = new DateTime.fromMillisecondsSinceEpoch(
+            x1.millisecondsSinceEpoch,
+            isUtc: true);
 
         test('$x1 => 1945-09-30 05:00:00.000Z', () {
           expect(u1.toString(), '1945-09-30 05:00:00.000Z');
         });
 
         final x2 = x1.subtract(const Duration(milliseconds: 1));
-        final u2 = new DateTime.fromMillisecondsSinceEpoch(x2.millisecondsSinceEpoch, isUtc: true);
+        final u2 = new DateTime.fromMillisecondsSinceEpoch(
+            x2.millisecondsSinceEpoch,
+            isUtc: true);
 
         test('$x2 => 1945-09-30 04:59:59.999Z', () {
           expect(u2.toString(), equals('1945-09-30 04:59:59.999Z'));
         });
 
         final x3 = x1.add(const Duration(milliseconds: 1));
-        final u3 = new DateTime.fromMillisecondsSinceEpoch(x3.millisecondsSinceEpoch, isUtc: true);
+        final u3 = new DateTime.fromMillisecondsSinceEpoch(
+            x3.millisecondsSinceEpoch,
+            isUtc: true);
 
         test('$x3 => 1945-09-30 05:00:00.001Z', () {
           expect(u3.toString(), equals('1945-09-30 05:00:00.001Z'));
         });
 
         final x4 = x1.add(const Duration(hours: 1));
-        final u4 = new DateTime.fromMillisecondsSinceEpoch(x4.millisecondsSinceEpoch, isUtc: true);
+        final u4 = new DateTime.fromMillisecondsSinceEpoch(
+            x4.millisecondsSinceEpoch,
+            isUtc: true);
 
         test('$x4 => 1945-09-30 06:00:00.000Z', () {
           expect(u4.toString(), equals('1945-09-30 06:00:00.000Z'));
         });
 
         final x5 = x2.add(const Duration(hours: 1));
-        final u5 = new DateTime.fromMillisecondsSinceEpoch(x5.millisecondsSinceEpoch, isUtc: true);
+        final u5 = new DateTime.fromMillisecondsSinceEpoch(
+            x5.millisecondsSinceEpoch,
+            isUtc: true);
 
         test('$x5 => 1945-09-30 05:59:59.999Z', () {
           expect(u5.toString(), equals('1945-09-30 05:59:59.999Z'));


### PR DESCRIPTION
Part of https://github.com/srawlins/timezone/issues/6; this PR fixes the errors in strong mode but not the warnings or hints yet. Specifically, it fixes:

```
[error] Missing concrete implementation of getter 'DateTime.microsecond' and getter 'DateTime.microsecondsSinceEpoch' (package:timezone/src/date_time.dart, line 11, col 7)
[error] Invalid override. The type of TZDateTime.difference ((TZDateTime) → Duration) is not a subtype of DateTime.difference ((DateTime) → Duration). (package:timezone/src/date_time.dart, line 321, col 3)
[error] Invalid override. The type of TZDateTime.isAtSameMomentAs ((TZDateTime) → bool) is not a subtype of DateTime.isAtSameMomentAs ((DateTime) → bool). (package:timezone/src/date_time.dart, line 386, col 3)
[error] Invalid override. The type of TZDateTime.compareTo ((TZDateTime) → int) is not a subtype of DateTime.compareTo ((DateTime) → int). (package:timezone/src/date_time.dart, line 396, col 3)
[error] Invalid override. The type of TimeZone.== ((TimeZone) → bool) is not a subtype of Object.== ((dynamic) → bool). (package:timezone/src/location.dart, line 240, col 3)
```

The main change is to store the canonical representation of a TZDateTime internally as a DateTime instead of millisecondsSinceEpoch. This allows for easier handling of microseconds without the problem of not being able to store microsecondsSinceEpoch in a JS number.

The constructors and modifiers (add, subtract) had to be changed to not use DateTime.fromMillisecondsSinceEpoch. It was possible to chain the constructors, simplifying them and allowing the internal fields to be final.