### PR TITLE
Fix pubspec dev dependencies

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,6 @@ dependencies:
   path: '^1.3.0'
 dev_dependencies:
   args: any
-  browser: any
   glob: any
   logging: any
-  test: '^0.12.0'
+  test: any


### PR DESCRIPTION
The package depended on the browser package (which has been discontinued, and doesn't have Dart 2 support). It also depended on an old version of the test package that didn't support Dart 2.

This change removed the browser dependency (I don't see where this was used. I suspect it was unused). It also switches to a newer version of the test package.