### PR TITLE
Local datetime

### DIFF
--- a/lib/src/date_time.dart
+++ b/lib/src/date_time.dart
@@ -194,7 +194,7 @@ class TZDateTime implements DateTime {
   /// ```
   TZDateTime.from(DateTime other, Location location)
       : this._(
-            _toNative(other),
+            _toNative(other).toUtc(),
             location,
             _isUtc(location)
                 ? TimeZone.UTC

--- a/test/datetime_test.dart
+++ b/test/datetime_test.dart
@@ -20,6 +20,14 @@ main() async {
       expect(t.toString(), equals('2010-01-01 22:04:05.006-0500'));
     });
 
+    test('from local DateTime', () {
+      final localTime = DateTime(2010, 1, 2, 3, 4, 5, 6);
+      final newYorkTime = TZDateTime.from(localTime, newYork);
+      // New York time should be 5 hours behind UTC.
+      expect(newYorkTime.hour,
+          equals(localTime.toUtc().subtract(Duration(hours: 5)).hour));
+    });
+
     test('from TZDateTime', () {
       final laTime = new TZDateTime(la, 2010, 1, 2, 3, 4, 5, 6);
       final t = new TZDateTime.from(laTime, newYork);


### PR DESCRIPTION
Fixes #18 

Convert local DateTime objects to UTC, if they are not already UTC.