### PR TITLE
Make TZDateTime.utc work even if you haven't initialized the database

### DIFF
--- a/lib/src/date_time.dart
+++ b/lib/src/date_time.dart
@@ -31,7 +31,12 @@ class TZDateTime implements DateTime {
       }
       unix -= tzData.timeZone.offset;
     }
-    return DateTime.fromMillisecondsSinceEpoch(unix, isUtc: true);
+    // Ensure original microseconds are preserved regardless of TZ shift.
+    final microsecondsSinceEpoch =
+        Duration(milliseconds: unix, microseconds: local.microsecond)
+            .inMicroseconds;
+    return DateTime.fromMicrosecondsSinceEpoch(microsecondsSinceEpoch,
+        isUtc: true);
   }
 
   /// Native [DateTime] used as a Calendar object.

--- a/lib/src/env.dart
+++ b/lib/src/env.dart
@@ -17,8 +17,9 @@ const String tzDataExtension = 'tzf';
 /// File name of the Time Zone default database.
 const String tzDataDefaultFilename = '$tzDataLatestVersion.$tzDataExtension';
 
+final Location _UTC = Location('UTC', [minTime], [0], [TimeZone.UTC]);
+
 LocationDatabase _database;
-Location _UTC;
 Location _local;
 
 /// Global TimeZone database
@@ -59,10 +60,6 @@ void initializeDatabase(List<int> rawData) {
 
   for (final Location l in tzdbDeserialize(rawData)) {
     _database.add(l);
-  }
-
-  if (_UTC == null) {
-    _UTC = Location('UTC', [minTime], [0], [TimeZone.UTC]);
   }
 
   if (_local == null) {

--- a/test/datetime_test.dart
+++ b/test/datetime_test.dart
@@ -10,14 +10,14 @@ main() async {
 
   group('Constructors', () {
     test('Default', () {
-      final t = TZDateTime(la, 2010, 1, 2, 3, 4, 5, 6);
-      expect(t.toString(), equals('2010-01-02 03:04:05.006-0800'));
+      final t = TZDateTime(la, 2010, 1, 2, 3, 4, 5, 6, 7);
+      expect(t.toString(), equals('2010-01-02 03:04:05.006007-0800'));
     });
 
     test('from DateTime', () {
-      final utcTime = DateTime.utc(2010, 1, 2, 3, 4, 5, 6);
+      final utcTime = DateTime.utc(2010, 1, 2, 3, 4, 5, 6, 7);
       final t = TZDateTime.from(utcTime, newYork);
-      expect(t.toString(), equals('2010-01-01 22:04:05.006-0500'));
+      expect(t.toString(), equals('2010-01-01 22:04:05.006007-0500'));
     });
 
     test('from local DateTime', () {
@@ -29,9 +29,9 @@ main() async {
     });
 
     test('from TZDateTime', () {
-      final laTime = TZDateTime(la, 2010, 1, 2, 3, 4, 5, 6);
+      final laTime = TZDateTime(la, 2010, 1, 2, 3, 4, 5, 6, 7);
       final t = TZDateTime.from(laTime, newYork);
-      expect(t.toString(), equals('2010-01-02 06:04:05.006-0500'));
+      expect(t.toString(), equals('2010-01-02 06:04:05.006007-0500'));
     });
 
     test('fromMilliseconds', () {
@@ -46,8 +46,8 @@ main() async {
     });
 
     test('utc', () {
-      final t = TZDateTime.utc(2010, 1, 2, 3, 4, 5, 6);
-      expect(t.toString(), equals('2010-01-02 03:04:05.006Z'));
+      final t = TZDateTime.utc(2010, 1, 2, 3, 4, 5, 6, 7);
+      expect(t.toString(), equals('2010-01-02 03:04:05.006007Z'));
     });
   });
 

--- a/test/datetime_test_no_database.dart
+++ b/test/datetime_test_no_database.dart
@@ -1,0 +1,11 @@
+@TestOn('vm')
+import 'package:test/test.dart';
+import 'package:timezone/standalone.dart';
+
+void main() {
+  group('Without initializing timezone database', () {
+    test('Can still construct TZDateTime.utc', () {
+      TZDateTime.utc(2019);
+    });
+  });
+}


### PR DESCRIPTION
Fixes #28 