### PR TITLE
Add earlier null assertions for TZDateTime constructors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.5.7-dev
+
+- Earlier null checking on some TZDateTime constructor arguments.
+
 # 0.5.6
 
 - Time zone database updated to 2019c. For your convenience here is the

--- a/lib/src/date_time.dart
+++ b/lib/src/date_time.dart
@@ -20,6 +20,8 @@ class TZDateTime implements DateTime {
 
   /// Converts a [_localDateTime] into a correct [DateTime].
   static DateTime _utcFromLocalDateTime(DateTime local, Location location) {
+    assert(local != null, "DateTime argument must not be null");
+    assert(location != null, "Location argument must not be null");
     var unix = local.millisecondsSinceEpoch;
     var tzData = location.lookupTimeZone(unix);
     if (tzData.timeZone.offset != 0) {
@@ -206,7 +208,8 @@ class TZDateTime implements DateTime {
                 : location.timeZone(other.millisecondsSinceEpoch));
 
   TZDateTime._(DateTime native, Location location, TimeZone timeZone)
-      : _native = native,
+      : assert(location != null, "Location argument must not be null"),
+        _native = native,
         _localDateTime =
             _isUtc(location) ? native : native.add(_timeZoneOffset(timeZone)),
         location = location,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,4 +14,4 @@ dev_dependencies:
   glob: any
   logging: any
   pedantic: ^1.4.0
-  test: any
+  test: ^1.10.0

--- a/test/datetime_test.dart
+++ b/test/datetime_test.dart
@@ -15,6 +15,15 @@ main() async {
       expect(t.toString(), equals('2010-01-02 03:04:05.006007-0800'));
     });
 
+    test('Default, only year argument', () {
+      final t = TZDateTime(la, 2010);
+      expect(t.toString(), equals('2010-01-01 00:00:00.000-0800'));
+    });
+
+    test('Default, null argument', () {
+      expect(() => TZDateTime(null, 2010), throwsA(isA<AssertionError>()));
+    });
+
     test('from DateTime', () {
       final utcTime = DateTime.utc(2010, 1, 2, 3, 4, 5, 6, 7);
       final t = TZDateTime.from(utcTime, newYork);


### PR DESCRIPTION
Earlier null checking on TZDateTime constructor arguments. Fixes #30 