### PR TITLE
Rename TimeZone.abbr to abbreviation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - **Breaking change**: Change some of TimeZone's constructor paramters to be
   named instead of positional.
+- **Breaking change**: Rename `TimeZone.abbr` to `TimeZone.abbreviation`.
 - Deprecate `LocationDatabase.isEmpty` in favor of
   `LocationDatabase.isInitialized`.
 

--- a/lib/src/date_time.dart
+++ b/lib/src/date_time.dart
@@ -421,7 +421,7 @@ class TZDateTime implements DateTime {
   /// The abbreviated time zone name&mdash;for example,
   /// [:"CET":] or [:"CEST":].
   @override
-  String get timeZoneName => timeZone.abbr;
+  String get timeZoneName => timeZone.abbreviation;
 
   /// The time zone offset, which is the difference between time at [location]
   /// and UTC.

--- a/lib/src/location.dart
+++ b/lib/src/location.dart
@@ -225,7 +225,7 @@ class Location {
 
 /// A [TimeZone] represents a single time zone such as CEST or CET.
 class TimeZone {
-  static const TimeZone UTC = TimeZone(0, isDst: false, abbr: 'UTC');
+  static const TimeZone UTC = TimeZone(0, isDst: false, abbreviation: 'UTC');
 
   /// Milliseconds east of UTC.
   final int offset;
@@ -234,9 +234,10 @@ class TimeZone {
   final bool isDst;
 
   /// Abbreviated name, "CET".
-  final String abbr;
+  final String abbreviation;
 
-  const TimeZone(this.offset, {required this.isDst, required this.abbr});
+  const TimeZone(this.offset,
+      {required this.isDst, required this.abbreviation});
 
   @override
   bool operator ==(dynamic other) {
@@ -244,7 +245,7 @@ class TimeZone {
         other is TimeZone &&
             offset == other.offset &&
             isDst == other.isDst &&
-            abbr == other.abbr;
+            abbreviation == other.abbreviation;
   }
 
   @override
@@ -252,12 +253,12 @@ class TimeZone {
     var result = 17;
     result = 37 * result + offset.hashCode;
     result = 37 * result + isDst.hashCode;
-    result = 37 * result + abbr.hashCode;
+    result = 37 * result + abbreviation.hashCode;
     return result;
   }
 
   @override
-  String toString() => '[$abbr offset=$offset dst=$isDst]';
+  String toString() => '[$abbreviation offset=$offset dst=$isDst]';
 }
 
 /// A [TzInstant] represents a timezone and an instant in time.

--- a/lib/src/tools.dart
+++ b/lib/src/tools.dart
@@ -529,7 +529,7 @@ Location tzfileLocationToNativeLocation(tzfile.Location loc) {
 
   for (final z in loc.zones) {
     zones.add(TimeZone(z.offset * 1000,
-        isDst: z.isDst, abbr: loc.abbrs[z.abbrIndex]));
+        isDst: z.isDst, abbreviation: loc.abbreviations[z.abbreviationIndex]));
   }
 
   return Location(loc.name, transitionAt, loc.transitionZone, zones);

--- a/lib/src/tzdata/zicfile.dart
+++ b/lib/src/tzdata/zicfile.dart
@@ -100,9 +100,10 @@ class TimeZone {
   final bool isDst;
 
   /// Index to abbreviation.
-  final int abbrIndex;
+  final int abbreviationIndex;
 
-  const TimeZone(this.offset, {required this.isDst, required this.abbrIndex});
+  const TimeZone(this.offset,
+      {required this.isDst, required this.abbreviationIndex});
 }
 
 /// Location data
@@ -117,7 +118,7 @@ class Location {
   final List<int> transitionZone;
 
   /// List of abbreviations.
-  final List<String> abbrs;
+  final List<String> abbreviations;
 
   /// List of [TimeZone]s.
   final List<TimeZone> zones;
@@ -136,8 +137,16 @@ class Location {
   /// UTC or local time.
   final List<int> isUtc;
 
-  Location(this.name, this.transitionAt, this.transitionZone, this.abbrs,
-      this.zones, this.leapAt, this.leapDiff, this.isStd, this.isUtc);
+  Location(
+      this.name,
+      this.transitionAt,
+      this.transitionZone,
+      this.abbreviations,
+      this.zones,
+      this.leapAt,
+      this.leapDiff,
+      this.isStd,
+      this.isUtc);
 
   /// Deserialize [Location] from bytes
   factory Location.fromBytes(String name, List<int> rawData) {
@@ -164,8 +173,9 @@ class Location {
         final transitionAtOffset = dataOffset;
         final transitionZoneOffset =
             transitionAtOffset + header.tzh_timecnt * 5;
-        final abbrsOffset = transitionZoneOffset + header.tzh_typecnt * 6;
-        final leapOffset = abbrsOffset + header.tzh_charcnt;
+        final abbreviationsOffset =
+            transitionZoneOffset + header.tzh_typecnt * 6;
+        final leapOffset = abbreviationsOffset + header.tzh_charcnt;
         final stdOrWctOffset = leapOffset + header.tzh_leapcnt * 8;
         final utcOrGmtOffset = stdOrWctOffset + header.tzh_ttisstdcnt;
 
@@ -185,17 +195,17 @@ class Location {
           offset += 1;
         }
 
-        // function to read from abbrev buffer
-        final abbrsData = data.buffer
-            .asUint8List(data.offsetInBytes + abbrsOffset, header.tzh_charcnt);
-        final abbrs = <String>[];
-        final abbrsCache = HashMap<int, int>();
-        int readAbbrev(int offset) {
-          var result = abbrsCache[offset];
+        // function to read from abbreviation buffer
+        final abbreviationsData = data.buffer.asUint8List(
+            data.offsetInBytes + abbreviationsOffset, header.tzh_charcnt);
+        final abbreviations = <String>[];
+        final abbreviationsCache = HashMap<int, int>();
+        int readAbbreviation(int offset) {
+          var result = abbreviationsCache[offset];
           if (result == null) {
-            result = abbrs.length;
-            abbrsCache[offset] = result;
-            abbrs.add(_readByteString(abbrsData, offset));
+            result = abbreviations.length;
+            abbreviationsCache[offset] = result;
+            abbreviations.add(_readByteString(abbreviationsData, offset));
           }
           return result;
         }
@@ -211,7 +221,8 @@ class Location {
           offset += 6;
 
           zones.add(TimeZone(tt_gmtoff,
-              isDst: tt_isdst == 1, abbrIndex: readAbbrev(tt_abbrind)));
+              isDst: tt_isdst == 1,
+              abbreviationIndex: readAbbreviation(tt_abbrind)));
         }
 
         // read leap seconds
@@ -243,8 +254,8 @@ class Location {
           offset += 1;
         }
 
-        return Location(name, transitionAt, transitionZone, abbrs, zones,
-            leapAt, leapDiff, isStd, isUtc);
+        return Location(name, transitionAt, transitionZone, abbreviations,
+            zones, leapAt, leapDiff, isStd, isUtc);
 
       case 50:
       case 51:
@@ -276,8 +287,9 @@ class Location {
         final transitionAtOffset = dataOffset;
         final transitionZoneOffset =
             transitionAtOffset + header2.tzh_timecnt * 9;
-        final abbrsOffset = transitionZoneOffset + header2.tzh_typecnt * 6;
-        final leapOffset = abbrsOffset + header2.tzh_charcnt;
+        final abbreviationsOffset =
+            transitionZoneOffset + header2.tzh_typecnt * 6;
+        final leapOffset = abbreviationsOffset + header2.tzh_charcnt;
         final stdOrWctOffset = leapOffset + header2.tzh_leapcnt * 12;
         final utcOrGmtOffset = stdOrWctOffset + header2.tzh_ttisstdcnt;
 
@@ -297,17 +309,17 @@ class Location {
           offset += 1;
         }
 
-        // function to read from abbrev buffer
-        final abbrsData = data.buffer
-            .asUint8List(data.offsetInBytes + abbrsOffset, header2.tzh_charcnt);
-        final abbrs = <String>[];
-        final abbrsCache = HashMap<int, int>();
-        int readAbbrev(int offset) {
-          var result = abbrsCache[offset];
+        // function to read from abbreviation buffer
+        final abbreviationsData = data.buffer.asUint8List(
+            data.offsetInBytes + abbreviationsOffset, header2.tzh_charcnt);
+        final abbreviations = <String>[];
+        final abbreviationsCache = HashMap<int, int>();
+        int readAbbreviation(int offset) {
+          var result = abbreviationsCache[offset];
           if (result == null) {
-            result = abbrs.length;
-            abbrsCache[offset] = result;
-            abbrs.add(_readByteString(abbrsData, offset));
+            result = abbreviations.length;
+            abbreviationsCache[offset] = result;
+            abbreviations.add(_readByteString(abbreviationsData, offset));
           }
           return result;
         }
@@ -323,7 +335,8 @@ class Location {
           offset += 6;
 
           zones.add(TimeZone(tt_gmtoff,
-              isDst: tt_isdst == 1, abbrIndex: readAbbrev(tt_abbrind)));
+              isDst: tt_isdst == 1,
+              abbreviationIndex: readAbbreviation(tt_abbrind)));
         }
 
         // read leap seconds
@@ -355,8 +368,8 @@ class Location {
           offset += 1;
         }
 
-        return Location(name, transitionAt, transitionZone, abbrs, zones,
-            leapAt, leapDiff, isStd, isUtc);
+        return Location(name, transitionAt, transitionZone, abbreviations,
+            zones, leapAt, leapDiff, isStd, isUtc);
 
       default:
         throw InvalidZoneInfoDataException('Unknown version: $version1');

--- a/test/zicfile_test.dart
+++ b/test/zicfile_test.dart
@@ -8,8 +8,10 @@ import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
 import 'package:timezone/tzdata.dart' as tzdata;
 
-tzdata.TimeZone z(int offset, {required bool isDst, required int abbrevIndex}) {
-  return tzdata.TimeZone(offset, isDst: isDst, abbrIndex: abbrevIndex);
+tzdata.TimeZone z(int offset,
+    {required bool isDst, required int abbreviationIndex}) {
+  return tzdata.TimeZone(offset,
+      isDst: isDst, abbreviationIndex: abbreviationIndex);
 }
 
 void main() {
@@ -23,7 +25,7 @@ void main() {
     final loc = tzdata.Location.fromBytes('US/Eastern', rawData);
 
     expect(loc.name, equals('US/Eastern'));
-    expect(loc.abbrs, equals(['LMT', 'EDT', 'EST', 'EWT', 'EPT']));
+    expect(loc.abbreviations, equals(['LMT', 'EDT', 'EST', 'EWT', 'EPT']));
     expect(loc.isStd, equals([0, 0, 0, 0, 1]));
     expect(loc.isUtc, equals([0, 0, 0, 0, 1]));
     expect(loc.leapAt, equals(<int>[]));


### PR DESCRIPTION
Also rewrite `abbr`, `abbrs`, `abbrev` and `abbrevs` in local code and comments wherever it did not directly reference the structure of the source tzdb file.