### PR TITLE
Remove `new` usage from examples, fix a typo in the TZDateTime.from example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 - **Breaking change**: Rename `TimeZone.abbr` to `TimeZone.abbreviation`.
 - Deprecate `LocationDatabase.isEmpty` in favor of
   `LocationDatabase.isInitialized`.
+- Removed `new` usage from examples and fixed a typo in the `TZDateTime.from`
+  example.  
 
 # 0.7.0-nullsafety.0
 

--- a/lib/browser.dart
+++ b/lib/browser.dart
@@ -9,7 +9,7 @@
 ///
 /// initializeTimeZone().then((_) {
 ///  final detroit = getLocation('America/Detroit');
-///  final now = new TZDateTime.now(detroit);
+///  final now = TZDateTime.now(detroit);
 /// });
 library timezone.browser;
 
@@ -40,7 +40,7 @@ const String tzDataDefaultPath =
 ///
 /// initializeTimeZone().then(() {
 ///   final detroit = getLocation('America/Detroit');
-///   final detroitNow = new TZDateTime.now(detroit);
+///   final detroitNow = TZDateTime.now(detroit);
 /// });
 /// ```
 Future<void> initializeTimeZone([String path = tzDataDefaultPath]) {

--- a/lib/src/date_time.dart
+++ b/lib/src/date_time.dart
@@ -86,7 +86,7 @@ class TZDateTime implements DateTime {
   /// True if this [TZDateTime] is set to UTC time.
   ///
   /// ```dart
-  /// final dDay = new TZDateTime.utc(1944, 6, 6);
+  /// final dDay = TZDateTime.utc(1944, 6, 6);
   /// assert(dDay.isUtc);
   /// ```
   ///
@@ -98,7 +98,7 @@ class TZDateTime implements DateTime {
   /// True if this [TZDateTime] is set to Local time.
   ///
   /// ```dart
-  /// final dDay = new TZDateTime.local(1944, 6, 6);
+  /// final dDay = TZDateTime.local(1944, 6, 6);
   /// assert(dDay.isLocal);
   /// ```
   ///
@@ -113,7 +113,7 @@ class TZDateTime implements DateTime {
   /// ```dart
   /// final detroit = getLocation('America/Detroit');
   ///
-  /// final annularEclipse = new TZDateTime(location,
+  /// final annularEclipse = TZDateTime(location,
   ///     2014, DateTime.APRIL, 29, 6, 4);
   /// ```
   TZDateTime(Location location, int year,
@@ -134,7 +134,7 @@ class TZDateTime implements DateTime {
   /// Constructs a [TZDateTime] instance specified in the UTC time zone.
   ///
   /// ```dart
-  /// final dDay = new TZDateTime.utc(1944, TZDateTime.JUNE, 6);
+  /// final dDay = TZDateTime.utc(1944, TZDateTime.JUNE, 6);
   /// ```
   TZDateTime.utc(int year,
       [int month = 1,
@@ -150,7 +150,7 @@ class TZDateTime implements DateTime {
   /// Constructs a [TZDateTime] instance specified in the local time zone.
   ///
   /// ```dart
-  /// final dDay = new TZDateTime.utc(1944, TZDateTime.JUNE, 6);
+  /// final dDay = TZDateTime.utc(1944, TZDateTime.JUNE, 6);
   /// ```
   TZDateTime.local(int year,
       [int month = 1,
@@ -169,7 +169,7 @@ class TZDateTime implements DateTime {
   /// ```dart
   /// final detroit = getLocation('America/Detroit');
   ///
-  /// final thisInstant = new TZDateTime.now(detroit);
+  /// final thisInstant = TZDateTime.now(detroit);
   /// ```
   TZDateTime.now(Location location) : this.from(DateTime.now(), location);
 
@@ -197,8 +197,8 @@ class TZDateTime implements DateTime {
   /// in the specified [location].
   ///
   /// ```dart
-  /// final laTime = new TZDateTime(la, 2010, 1, 1);
-  /// final detroitTime = new TZDateTime.from(detroit, laTime);
+  /// final laTime = TZDateTime(la, 2010, 1, 1);
+  /// final detroitTime = TZDateTime.from(laTime, detroit);
   /// ```
   TZDateTime.from(DateTime other, Location location)
       : this._(
@@ -348,8 +348,8 @@ class TZDateTime implements DateTime {
   ///
   /// ```dart
   /// final detroit   = getLocation('America/Detroit');
-  /// final dDayUtc   = new TZDateTime.utc(1944, DateTime.JUNE, 6);
-  /// final dDayLocal = new TZDateTime(detroit, 1944, DateTime.JUNE, 6);
+  /// final dDayUtc   = TZDateTime.utc(1944, DateTime.JUNE, 6);
+  /// final dDayLocal = TZDateTime(detroit, 1944, DateTime.JUNE, 6);
   ///
   /// assert(dDayUtc.isAtSameMomentAs(dDayLocal) == false);
   /// ````
@@ -369,8 +369,8 @@ class TZDateTime implements DateTime {
   /// time zone.
   ///
   /// ```dart
-  /// final berlinWallFell = new TZDateTime(UTC, 1989, 11, 9);
-  /// final moonLanding    = new TZDateTime(UTC, 1969, 7, 20);
+  /// final berlinWallFell = TZDateTime(UTC, 1989, 11, 9);
+  /// final moonLanding    = TZDateTime(UTC, 1969, 7, 20);
   ///
   /// assert(berlinWallFell.isBefore(moonLanding) == false);
   /// ```
@@ -383,8 +383,8 @@ class TZDateTime implements DateTime {
   /// time zone.
   ///
   /// ```dart
-  /// final berlinWallFell = new TZDateTime(UTC, 1989, 11, 9);
-  /// final moonLanding    = new TZDateTime(UTC, 1969, 7, 20);
+  /// final berlinWallFell = TZDateTime(UTC, 1989, 11, 9);
+  /// final moonLanding    = TZDateTime(UTC, 1969, 7, 20);
   ///
   /// assert(berlinWallFell.isAfter(moonLanding) == true);
   /// ```
@@ -397,8 +397,8 @@ class TZDateTime implements DateTime {
   /// time zone.
   ///
   /// ```dart
-  /// final berlinWallFell = new TZDateTime(UTC, 1989, 11, 9);
-  /// final moonLanding    = new TZDateTime(UTC, 1969, 7, 20);
+  /// final berlinWallFell = TZDateTime(UTC, 1989, 11, 9);
+  /// final moonLanding    = TZDateTime(UTC, 1969, 7, 20);
   ///
   /// assert(berlinWallFell.isAtSameMomentAs(moonLanding) == false);
   /// ```

--- a/lib/src/location_database.dart
+++ b/lib/src/location_database.dart
@@ -12,7 +12,7 @@ import 'location.dart';
 ///
 ///     List<int> data = load(); // load database
 ///
-///     LocationDatabase db = new LocationDatabase.fromBytes(data);
+///     LocationDatabase db = LocationDatabase.fromBytes(data);
 ///     Location loc = db.get('US/Eastern');
 ///
 class LocationDatabase {

--- a/lib/standalone.dart
+++ b/lib/standalone.dart
@@ -9,7 +9,7 @@
 ///
 /// initializeTimeZone().then((_) {
 ///  final detroit = getLocation('America/Detroit');
-///  final now = new TZDateTime.now(detroit);
+///  final now = TZDateTime.now(detroit);
 /// });
 /// ```
 library timezone.standalone;
@@ -69,7 +69,7 @@ Future<List<int>> _loadAsBytes(String path) async {
 ///
 /// initializeTimeZone().then(() {
 ///   final detroit = getLocation('America/Detroit');
-///   final detroitNow = new TZDateTime.now(detroit);
+///   final detroitNow = TZDateTime.now(detroit);
 /// });
 /// ```
 Future<void> initializeTimeZone([String? path]) {


### PR DESCRIPTION
The `TZDateTime.from` example accidentally swapped the `DateTime` and
`Location` arguments.  While I'm touching this, remove `new` usage
from the various examples.