### PR TITLE
Better errors and tests for getLocation

### DIFF
--- a/lib/src/location_database.dart
+++ b/lib/src/location_database.dart
@@ -28,6 +28,13 @@ class LocationDatabase {
 
   /// Finds [Location] by its name.
   Location get(String name) {
+    if (!isInitialized) {
+      // Before you can get a location, you need to manually initialize the
+      // timezone location database by calling initializeDatabase or similar.
+      throw LocationNotFoundException(
+          'Tried to get location before initializing timezone database');
+    }
+
     final loc = _locations[name];
     if (loc == null) {
       throw LocationNotFoundException(

--- a/test/datetime_test.dart
+++ b/test/datetime_test.dart
@@ -154,5 +154,14 @@ Future<void> main() async {
         });
       });
     });
+  });  
+  
+  group('Timezones', () {
+    test(
+        'getLocation throws $LocationNotFoundException for unrecognized timezone',
+        () {
+      expect(() => getLocation('non-existent-location'),
+          throwsA(TypeMatcher<LocationNotFoundException>()));
+    });
   });
 }

--- a/test/datetime_test_no_database.dart
+++ b/test/datetime_test_no_database.dart
@@ -1,11 +1,21 @@
 @TestOn('vm')
 import 'package:test/test.dart';
 import 'package:timezone/standalone.dart';
+import 'package:timezone/timezone.dart';
 
 void main() {
   group('Without initializing timezone database', () {
     test('Can still construct TZDateTime.utc', () {
       TZDateTime.utc(2019);
+    });
+
+    test(
+        'getLocation throws $LocationNotFoundException with message about the database not being initialized',
+        () {
+      expect(
+          () => getLocation('America/New_York'),
+          throwsA(TypeMatcher<LocationNotFoundException>()
+              .having((e) => e.msg, 'msg', contains('database'))));
     });
   });
 }


### PR DESCRIPTION
* Throw a LocationNotFoundException with a custom message if the timezone database hasn't yet been initialized (makes it easier for developers to discover how to fix the isssue)
* Add a test for this custom error message
* Add a (missing) test for the other time getLocation throws a LocationNotFoundException (unrecognized timezone)