### PR TITLE
Update refresh.sh to use explicit `-b fat` option

### DIFF
--- a/tool/refresh.sh
+++ b/tool/refresh.sh
@@ -14,7 +14,7 @@ curl https://data.iana.org/time-zones/tzdata-latest.tar.gz | tar -zx
 
 echo "Compiling into zoneinfo files..."
 mkdir zoneinfo
-zic -d zoneinfo africa antarctica asia australasia etcetera europe \
+zic -d zoneinfo -b fat africa antarctica asia australasia etcetera europe \
                 northamerica southamerica backward
 
 popd > /dev/null


### PR DESCRIPTION
`zic` changed the default value of `-b` from `fat` to `slim` in 2020c. Using `slim` may result in incorrectly generated transition times.