### PR TITLE
Bump lints and file deps

### DIFF
--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -47,7 +47,7 @@ jobs:
       matrix:
         # Add macos-latest and/or windows-latest if relevant for this package.
         os: [ubuntu-latest]
-        sdk: [2.19.0, dev]
+        sdk: [3.3.0, dev]
     steps:
       - uses: actions/checkout@v2
       - uses: dart-lang/setup-dart@v1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 0.9.3
 
-- Time zone database updated to 2024d. For your convenience here are the
+- Time zone database updated to 2024a. For your convenience here are the
   announcements for [2023d], [2024a].
 
 [2023d]: https://mm.icann.org/pipermail/tz-announce/2023-December.txt

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -18,11 +18,7 @@ linter:
     - avoid_dynamic_calls
     - avoid_positional_boolean_parameters
     - avoid_unused_constructor_parameters
-    - dangling_library_doc_comments
     - directives_ordering
-    - collection_methods_unrelated_type
-    - implicit_call_tearoffs
-    - library_annotations
     - lines_longer_than_80_chars
     - package_api_docs
     - prefer_asserts_in_initializer_lists
@@ -31,4 +27,3 @@ linter:
     - unnecessary_library_directive
     - unnecessary_parenthesis
     - unreachable_from_main
-    - use_super_parameters

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,8 +8,8 @@ dependencies:
   path: ^1.8.0
 dev_dependencies:
   args: any
-  file: ^6.0.0
+  file: '>=6.0.0 <8.0.0'
   glob: ^2.0.0
-  lints: ^2.0.0
-  logging: any
+  lints: ^3.0.0
+  logging: ^1.2.0
   test: ^1.16.0


### PR DESCRIPTION
* Remove lint rules that are included in lints 3.0.0
* Fix CHANGELOG typo
* Give version constraints for logging.