### PR TITLE
Update refresh.sh to use rearguard file

### DIFF
--- a/tool/refresh.sh
+++ b/tool/refresh.sh
@@ -14,8 +14,8 @@ curl https://data.iana.org/time-zones/tzdata-latest.tar.gz | tar -zx
 
 echo "Compiling into zoneinfo files..."
 mkdir zoneinfo
-zic -d zoneinfo -b fat africa antarctica asia australasia etcetera europe \
-                northamerica southamerica backward
+make rearguard.zi
+zic -d zoneinfo -b fat rearguard.zi
 
 popd > /dev/null
 


### PR DESCRIPTION
Update refresh.sh to use rearguard file to properly handle timezones with negative DST offset (e.g. Europe/Dublin).

The original caused timezones with negative DST (like Europe/Dublin) to have isDst set inverse of expectations for CLDR (e.g. false in summer, true in winter). This causes problems in case the isDST flag is used to get the timezone names from e.g. CLDR.

(See for example this mailchain: [https://bugs.openjdk.org/browse/JDK-8195595], and CLDR documentation: https://cldr.unicode.org/development/updating-codes/update-time-zone-data-for-zoneparser)