### PR TITLE
Fixed tests on windows

### DIFF
--- a/lib/src/tzdata/zone_tab.dart
+++ b/lib/src/tzdata/zone_tab.dart
@@ -56,7 +56,7 @@ class LocationDescriptionDatabase {
   LocationDescriptionDatabase(this.locations);
 
   factory LocationDescriptionDatabase.fromString(String data) {
-    final lines = data.split('\n');
+    final lines = data.replaceAll('\r\n', '\n').split('\n');
     final locations = <LocationDescription>[];
     for (final line in lines) {
       if (line.isEmpty || line[0].startsWith('#')) {

--- a/test/zicfile_test.dart
+++ b/test/zicfile_test.dart
@@ -12,7 +12,7 @@ void main() {
   test('Read US/Eastern 2014h tzfile', () async {
     var packageUri = Uri(scheme: 'package', path: 'timezone/timezone.dart');
     var packagePath = p.dirname(
-        p.dirname((await Isolate.resolvePackageUri(packageUri))!.path));
+        p.dirname((await Isolate.resolvePackageUri(packageUri))!.toFilePath()));
     var locationDir = p.join(packagePath, 'test');
     var rawData =
         await File(p.join(locationDir, 'data/US/Eastern')).readAsBytes();

--- a/test/zone_tab_test.dart
+++ b/test/zone_tab_test.dart
@@ -12,7 +12,7 @@ void main() {
   test('Read zone1970.tab file', () async {
     var packageUri = Uri(scheme: 'package', path: 'timezone/timezone.dart');
     var packagePath = p.dirname(
-        p.dirname((await Isolate.resolvePackageUri(packageUri))!.path));
+        p.dirname((await Isolate.resolvePackageUri(packageUri))!.toFilePath()));
     var locationDir = p.join(packagePath, 'test');
     var rawData =
         await File(p.join(locationDir, 'data/zone1970.tab')).readAsString();

--- a/tool/encode_tzf.dart
+++ b/tool/encode_tzf.dart
@@ -48,7 +48,7 @@ Future<void> main(List<String> arguments) async {
   final files = await Glob('**').list(root: zoneinfoPath).toList();
   for (final f in files) {
     if (f is pkg_file.File) {
-      final name = p.relative(f.path, from: zoneinfoPath);
+      final name = p.relative(f.path, from: zoneinfoPath).replaceAll('\\', '/');
       log.info('- $name');
       db.add(tzfileLocationToNativeLocation(
           tzfile.Location.fromBytes(name, await f.readAsBytes())));


### PR DESCRIPTION
Tests failed on windows due to incorrect path to data files (starting with /) and missing handling of \r\n